### PR TITLE
Remove unnecessary mutability

### DIFF
--- a/src/codec/codec007.rs
+++ b/src/codec/codec007.rs
@@ -83,7 +83,7 @@ pub fn decode_fli_ss2(src: &[u8], dst: &mut RasterMut)
 
         let start = dst.stride * (dst.y + y);
         let end = dst.stride * (dst.y + y + 1);
-        let mut row = &mut dst.buf[start..end];
+        let row = &mut dst.buf[start..end];
         let mut x0 = dst.x;
 
         for _ in 0..count {

--- a/src/codec/codec015.rs
+++ b/src/codec/codec015.rs
@@ -47,7 +47,7 @@ pub fn decode_fli_brun(src: &[u8], dst: &mut RasterMut)
     for row in dst.buf[start..end].chunks_mut(dst.stride) {
         let start = dst.x;
         let end = start + dst.w;
-        let mut row = &mut row[start..end];
+        let row = &mut row[start..end];
         let mut x0 = 0;
 
         // Skip obsolete count byte.


### PR DESCRIPTION
This was generating warnings:

```
warning: variable does not need to be mutable
  --> src/codec/codec007.rs:86:13
   |
86 |         let mut row = &mut dst.buf[start..end];
   |             ----^^^
   |             |
   |             help: remove this `mut`
   |
   = note: #[warn(unused_mut)] on by default

warning: variable does not need to be mutable
  --> src/codec/codec015.rs:50:13
   |
50 |         let mut row = &mut row[start..end];
   |             ----^^^
   |             |
   |             help: remove this `mut`
```